### PR TITLE
Harden request flow: redirects, errors, timeout, session reuse, concurrency, optional body

### DIFF
--- a/agent-slammer.py
+++ b/agent-slammer.py
@@ -15,56 +15,96 @@ __version__ = "0.0.3"
 app = typer.Typer()
 logger = logging.getLogger(__name__)
 
+# Single source of truth for CSV columns — must stay in sync with the keys
+# request() emits. Add a column here and in request() together.
+REPORT_FIELDS = [
+    "agent",
+    "url",
+    "status code",
+    "final url",
+    "redirect chain",
+    "response headers",
+    "cookies",
+    "response length",
+    "response text",
+    "error",
+]
 
-async def tasker(target: str, agents: json) -> List[dict]:
-    if target and agents:
-        reqtasks = []
+
+async def tasker(
+    target: str,
+    agents: List[dict],
+    concurrency: int,
+    timeout: float,
+    include_body: bool,
+) -> List[dict]:
+    if not (target and agents):
+        return []
+    sem = asyncio.Semaphore(concurrency)
+    timeout_cfg = aiohttp.ClientTimeout(total=timeout)
+    async with aiohttp.ClientSession(timeout=timeout_cfg) as session:
+        tasks = [
+            asyncio.create_task(request(session, sem, target, agent["ua"], include_body))
+            for agent in agents
+        ]
         reqlog = []
-        for agent in track(agents, description="Building task list"):
-            task = asyncio.create_task(request(target=target, agent=agent["ua"]))
-            reqtasks.append(task)
-        for reqtask in track(reqtasks, description="Performing queries"):
-            reqlog.append(await reqtask)
-        return reqlog
-    pass
+        for task in track(tasks, description="Performing queries"):
+            reqlog.append(await task)
+    return reqlog
 
-async def request(target: str, agent: str) -> dict:
-    if target and agent:
-        async with aiohttp.ClientSession() as session:
+
+async def request(
+    session: aiohttp.ClientSession,
+    sem: asyncio.Semaphore,
+    target: str,
+    agent: str,
+    include_body: bool,
+) -> dict:
+    # All keys present up front so every row is uniform for the CSV writer.
+    reqdata = {
+        "agent": agent,
+        "url": target,
+        "status code": "",
+        "final url": "",
+        "redirect chain": "",
+        "response headers": "",
+        "cookies": "",
+        "response length": "",
+        "response text": "",
+        "error": "",
+    }
+    try:
+        async with sem:  # ponytail: guards the GET, not task creation — create_task starts work immediately
             async with session.get(target, headers={"user-agent": agent}) as req:
-                reqdata = {
-                    "agent": agent,
-                    "url": target,
-                    "status code": req.status,
-                    "response headers": req.headers,
-                    "cookies": req.cookies,
-                    "response text": (await req.text()),
-                }
-        return reqdata
-    else:
-        logger.critical("CHECK-FAIL: Missing target URL and/or user agents")
+                text = await req.text()
+                reqdata.update(
+                    {
+                        "status code": req.status,
+                        "final url": str(req.url),
+                        "redirect chain": " -> ".join(str(h.url) for h in req.history),
+                        "response headers": req.headers,
+                        "cookies": req.cookies,
+                        "response length": len(text),
+                        "response text": text if include_body else "",
+                    }
+                )
+    except Exception as exc:  # ponytail: broad on purpose — a validation run must never lose a row
+        reqdata["error"] = f"{type(exc).__name__}: {exc}"
+        logger.warning("REQUEST-FAIL [%s]: %s", agent, exc)
+    return reqdata
 
 
 def reporter(reppath: Path, repdata: List[dict]) -> None:
-    if reppath and repdata:
-        with open(reppath.resolve(), "a", encoding="utf-8") as repobj:
-            writer = DictWriter(
-                repobj,
-                [
-                    "agent",
-                    "url",
-                    "status code",
-                    "request headers",
-                    "response headers",
-                    "cookies",
-                    "response text",
-                ],
-            )
-            writer.writeheader()
-            for entry in repdata:
-                writer.writerow(entry)
-    else:
+    if not (reppath and repdata):
         logger.critical("CHECK-FAIL: Missing report path and/or report data")
+        return
+    reppath = reppath.resolve()
+    write_header = not reppath.exists() or reppath.stat().st_size == 0
+    with open(reppath, "a", encoding="utf-8", newline="") as repobj:
+        writer = DictWriter(repobj, REPORT_FIELDS, extrasaction="ignore")
+        if write_header:
+            writer.writeheader()
+        writer.writerows(repdata)
 
 
 @app.command()
@@ -75,20 +115,29 @@ def slam(
         default=Path("user-agents.json"),
         help="JSON file containing the user agent strings"
         ),
+    concurrency: int = typer.Option(
+        20, help="Max requests in flight at once"
+    ),
+    timeout: float = typer.Option(
+        10.0, help="Per-request timeout in seconds"
+    ),
+    body: bool = typer.Option(
+        False, "--body", help="Store full response text (large)"
+    ),
     verbose: int = typer.Option(
         0, "-v", count=True, max=4, help="Log verbosity level"
     ),
 ) -> None:
-    if url and report:
-        logging.basicConfig(level=(((verbose + 5) * 10) - (verbose * 20)))
-        f = open(agents)
-        agents = json.load(f)
-        report = Path(report)
-        reporter(
-            reppath=report, repdata=(asyncio.run(tasker(target=url, agents=agents)))
-        )
-    else:
+    if not (url and report):
         logger.critical("CHECK-FAIL: Missing target URL and/or report path")
+        return
+    logging.basicConfig(level=max(10, 50 - verbose * 10))
+    with open(agents) as f:
+        agent_list = json.load(f)
+    reporter(
+        reppath=Path(report),
+        repdata=asyncio.run(tasker(url, agent_list, concurrency, timeout, body)),
+    )
 
 
 if __name__ == "__main__":

--- a/specs/01-redirects-and-errors.md
+++ b/specs/01-redirects-and-errors.md
@@ -1,0 +1,83 @@
+# 01 — Redirects & Per-Request Errors
+
+## Spec
+
+### Problem
+`agent-slammer` fires a GET per user-agent and records `req.status` plus headers/cookies/body. Two gaps:
+
+1. **No redirect evidence.** aiohttp follows redirects by default, so `req.status` is the *final* status and the recorded `url` is the *requested* URL. If a mobile UA is redirected to `m.site.com` or an unsupported UA to `/not-supported`, the CSV looks identical to a UA that got served in-place at 200. The redirect *is* the device-flow signal, and right now it's invisible.
+2. **No error isolation or timeout.** `request()` has no try/except and no timeout. A dead endpoint hangs the run forever (no timeout); a single `aiohttp.ClientError` raised at `await reqtask` in `tasker()` crashes the whole run and discards *every* result already gathered.
+
+### Why it matters for device-flow validation
+The entire point of the tool is confirming "UA X lands on flow Y". Without the final URL and redirect chain there's no way to assert that. Without per-request error handling, one flaky UA (or one slow origin) either loses the whole report or makes it appear the tool "did nothing" — false negatives in a validation tool are worse than useless.
+
+### Acceptance criteria
+Each row already has: `agent`, `url`, `status code`, `response headers`, `cookies`, `response text`. Add `final url`, `redirect chain`, `error`. Then:
+
+- **Redirected request** (UA → `m.site.com`): row has `status code` = final status (e.g. 200), `final url` = `https://m.site.com/...`, `redirect chain` = `https://site.com/... -> https://m.site.com/...` (the pre-final URLs, `" -> "`-joined), `error` empty.
+- **Non-redirected request**: `final url` = requested `url`, `redirect chain` empty, `error` empty.
+- **Timed-out request**: a row still exists for that UA; `status code`, `final url`, `redirect chain`, body/headers/cookies empty; `error` populated, e.g. `TimeoutError: ` (or `asyncio.TimeoutError`, whichever aiohttp surfaces). The run does **not** hang past the timeout and does **not** abort other UAs.
+- **Connection error** (bad host, refused): row exists; `error` populated, e.g. `ClientConnectorError: Cannot connect to host ...`; other UAs unaffected.
+
+## Plan
+
+Minimal, aiohttp-native, no new deps, no new abstractions.
+
+### `request()` — rewrite the body
+- Add a `timeout: float` parameter (seconds).
+- Build the result dict up front with **all** keys present and empty defaults so every row is uniform (DictWriter needs every key present):
+  ```
+  reqdata = {agent, url, "status code": "", "final url": "", "redirect chain": "",
+             "response headers": "", "cookies": "", "response text": "", "error": ""}
+  ```
+- Wrap the session/get in `try/except Exception as exc:`. On success, fill:
+  - `"status code": req.status`
+  - `"final url": str(req.url)`
+  - `"redirect chain": " -> ".join(str(h.url) for h in req.history)`
+  - `"response headers"`, `"cookies"`, `"response text"` as today.
+- On failure: `reqdata["error"] = f"{type(exc).__name__}: {exc}"` and `logger.warning(...)`. Catch broad `Exception` on purpose — a validation run must never lose a row; `ponytail:` comment marks it.
+- Pass the timeout to aiohttp: `aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=timeout))`. This covers the whole request incl. redirect following, so a slow chain also trips it.
+- Return `reqdata` in all paths (drop the `else: logger.critical` — the missing-inputs guard stays as an early check that returns the empty dict, or keep the existing `if target and agent` and just return the error-populated dict).
+
+### `tasker()` — thread the timeout
+- Add `timeout: float` param; pass to `request(...)`.
+- `await reqtask` can no longer raise (request swallows its own errors), so the gather loop is now crash-safe as-is. No other change.
+
+### `reporter()` — keep fieldnames in sync
+The `DictWriter` fieldnames list is the source of truth and **must** match the dict keys exactly (DictWriter raises `ValueError` on extra keys). Update it to:
+```
+["agent", "url", "status code", "final url", "redirect chain",
+ "response headers", "cookies", "response text", "error"]
+```
+Note: the current list contains `"request headers"`, which no dict ever sets (it writes blank). Leave it or drop it — out of scope; do not add data for it. Just make sure every key `request()` emits appears here.
+
+### `slam()` — CLI
+Add one option:
+```
+timeout: float = typer.Option(10.0, help="Per-request timeout in seconds"),
+```
+Thread it: `asyncio.run(tasker(target=url, agents=agents, timeout=timeout))`. Default 10s — a real device-flow endpoint answers fast; 10s is generous without hanging a run on one dead UA.
+
+### Not doing (YAGNI)
+- No retry logic, no per-attempt backoff, no separate redirect-disable mode. If someone later needs the raw 3xx statuses without following, add `allow_redirects=False` behind a flag then.
+- No structured error object — a `Type: message` string is enough for a CSV a human reads.
+
+## Runnable check
+One assert-based self-check, no network, no framework. Point `request()` at an unroutable/invalid target and assert the returned row is populated with an error and no status:
+
+```python
+# tacked into agent-slammer.py under __main__, or a test_request.py
+import asyncio
+
+def test_error_row_populated():
+    row = asyncio.run(request(target="http://127.0.0.1:1/", agent="pytest-ua", timeout=1.0))
+    assert row["error"], "error column must be populated on failure"
+    assert row["status code"] == "", "no status on a failed request"
+    assert row["agent"] == "pytest-ua"     # row still identifies its UA
+    assert "final url" in row and "redirect chain" in row  # keys present for DictWriter
+
+if __name__ == "__main__":
+    test_error_row_populated()
+    print("ok")
+```
+Port 1 refuses/times out fast, so this runs offline in ~1s and fails loudly if the try/except or the uniform-keys contract regresses. (Redirect-chain formatting is a one-line `" -> ".join(...)` over `req.history` and needs no dedicated test.)

--- a/specs/03-session-reuse.md
+++ b/specs/03-session-reuse.md
@@ -1,0 +1,152 @@
+# 03 — Reuse one aiohttp.ClientSession per run
+
+## Spec
+
+### Problem
+`request()` opens a fresh `aiohttp.ClientSession()` for every user-agent:
+
+```python
+async def request(target: str, agent: str) -> dict:
+    ...
+    async with aiohttp.ClientSession() as session:
+        async with session.get(...) as req:
+            ...
+```
+
+Across a UA list of hundreds, that is hundreds of sessions created and torn
+down — one per request.
+
+### Why per-request sessions are wrong
+- **Connection pooling is defeated.** A `ClientSession` owns the `TCPConnector`
+  and its keep-alive pool. A session per request means a new connector, a new
+  TCP (and TLS) handshake every time, and nothing reused — the exact thing
+  pooling exists to avoid.
+- **Overhead.** Each session allocates a connector, cookie jar, and event-loop
+  bookkeeping, then immediately discards them. aiohttp's own docs are explicit:
+  create the session **once** and reuse it for the lifetime of the work.
+
+### Acceptance criteria
+- Exactly **one** `ClientSession` is constructed per `tasker()` run, regardless
+  of agent count.
+- `request()` **receives** a session; it does not create or close one.
+- The session is created as an `async with` context in `tasker()` so it is
+  cleanly closed after all requests complete.
+- No new dependencies. Response shape and CSV output unchanged.
+
+## Plan
+
+Two edits, both native aiohttp, minimal diff.
+
+### 1. `request()` — take a session, drop the `async with ClientSession()`
+Signature gains `session`; the inner session-creation line is removed:
+
+```python
+async def request(target: str, agent: str, session: aiohttp.ClientSession) -> dict:
+    if target and agent:
+        async with session.get(target, headers={"user-agent": agent}) as req:
+            reqdata = {
+                "agent": agent,
+                "url": target,
+                "status code": req.status,
+                "response headers": req.headers,
+                "cookies": req.cookies,
+                "response text": (await req.text()),
+            }
+        return reqdata
+    else:
+        logger.critical("CHECK-FAIL: Missing target URL and/or user agents")
+```
+
+### 2. `tasker()` — create the session once, pass it in
+Wrap task creation in the session context and forward `session`:
+
+```python
+async def tasker(target: str, agents: json) -> List[dict]:
+    if target and agents:
+        reqtasks = []
+        reqlog = []
+        async with aiohttp.ClientSession() as session:
+            for agent in track(agents, description="Building task list"):
+                task = asyncio.create_task(
+                    request(target=target, agent=agent["ua"], session=session)
+                )
+                reqtasks.append(task)
+            for reqtask in track(reqtasks, description="Performing queries"):
+                reqlog.append(await reqtask)
+        return reqlog
+    pass
+```
+
+The `async with` must stay open until every task is awaited (both loops inside
+the block, as shown) — closing the session before the requests resolve would
+cancel them.
+
+### Resulting signatures
+- `async def tasker(target: str, agents: json) -> List[dict]` — unchanged
+  signature; body now owns the single session.
+- `async def request(target: str, agent: str, session: aiohttp.ClientSession) -> dict`
+  — gains `session`.
+
+## Interaction note
+This change edits the **same two functions** (`tasker`, `request`) as:
+- the **redirects/errors** spec (adds error handling around `session.get`), and
+- the **concurrency** spec (swaps the sequential await loop for
+  `asyncio.gather`/a semaphore).
+
+If these ship separately, coordinate ordering to avoid conflicting rewrites of
+the same lines — land this one first, since a shared session is a prerequisite
+for the others (gather over a single pooled session; timeouts/retries on that
+session).
+
+**ClientTimeout attaches on the session constructor.** When the errors spec
+adds a timeout, it belongs here:
+`aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=...))` — one timeout
+config for the whole run, applied by the single session created in `tasker()`.
+
+## Runnable check
+Monkeypatch `aiohttp.ClientSession` to count instantiations and assert it is
+constructed exactly once regardless of agent count. Save as `test_session_reuse.py`:
+
+```python
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import agent_slammer as slammer  # adjust import to how the module is loaded
+
+
+def test_one_session_per_run():
+    count = {"n": 0}
+
+    def fake_session_factory(*args, **kwargs):
+        count["n"] += 1
+        resp = AsyncMock()
+        resp.status = 200
+        resp.headers = {}
+        resp.cookies = {}
+        resp.text = AsyncMock(return_value="ok")
+
+        # session.get(...) returns an async context manager yielding resp
+        get_cm = MagicMock()
+        get_cm.__aenter__ = AsyncMock(return_value=resp)
+        get_cm.__aexit__ = AsyncMock(return_value=False)
+
+        session = MagicMock()
+        session.get = MagicMock(return_value=get_cm)
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=False)
+        return session
+
+    agents = [{"ua": f"UA-{i}"} for i in range(100)]
+    with patch("aiohttp.ClientSession", side_effect=fake_session_factory):
+        asyncio.run(slammer.tasker(target="http://example.test", agents=agents))
+
+    assert count["n"] == 1, f"expected 1 session, got {count['n']}"
+
+
+if __name__ == "__main__":
+    test_one_session_per_run()
+    print("ok: 1 session for 100 agents")
+```
+
+100 agents through `tasker()` must still yield exactly one `ClientSession`
+construction. Before the change this asserts `100`; after, `1`.

--- a/specs/04-reporter-header.md
+++ b/specs/04-reporter-header.md
@@ -1,0 +1,100 @@
+# 04 — Reporter: duplicate header row + phantom column
+
+## Spec
+
+`reporter()` writes per-request dicts to a CSV. Two defects corrupt the output.
+
+### Defect 1 — unconditional header row in append mode
+The file is opened `"a"` (append) but `writer.writeheader()` runs every call. Point
+the tool at the same report path twice and a second header row lands in the middle
+of the data. The CSV becomes unparseable by anything that trusts the first row as the
+schema — a header line reappears as a fake data row.
+
+### Defect 2 — phantom `request headers` column
+`fieldnames` lists `"request headers"`, but no row dict ever carries that key. Every
+row leaves that column blank, so the CSV advertises a column that is always empty —
+misleading, and a trap for downstream code that assumes columns map to data.
+
+### Acceptance criteria
+- Running `reporter()` twice against the same file yields **exactly one** header row.
+- Every column in `fieldnames` has a corresponding key in the row dicts (no always-blank columns).
+- No blank interstitial lines between rows (Windows CSV newline handling).
+- Fieldname/row drift never raises — extra keys on a row are silently dropped, not fatal.
+
+## Plan
+
+Changes to `reporter()` in `agent-slammer.py`:
+
+1. **Header only when new/empty.** Guard `writeheader()` with
+   `if not reppath.exists() or reppath.stat().st_size == 0:`. Compute this *before*
+   opening in append mode (opening `"a"` does not change size, but read it first for clarity).
+2. **Drop `"request headers"`** from the fieldnames.
+3. **Open with `newline=""`** — the csv module's documented requirement; prevents blank
+   lines between rows on Windows.
+4. **`extrasaction="ignore"`** on `DictWriter` — if a row later gains keys the fieldnames
+   don't list, they're skipped instead of raising.
+
+### Single source of truth for columns
+Multiple specs touch the CSV columns (`final url`, `redirect chain`, `error` are being
+added elsewhere). Promote the fieldnames to a module-level constant so every spec edits
+one list and the row dicts and writer stay in sync:
+
+```python
+REPORT_FIELDS = [
+    "agent",
+    "url",
+    "status code",
+    "response headers",
+    "cookies",
+    "response text",
+]
+```
+
+> Sync note: whoever adds `final url` / `redirect chain` / `error` appends them here **and**
+> to the per-request dict. Fieldnames and row keys must move together — that is the whole
+> point of the constant. `extrasaction="ignore"` covers a row having *fewer* keys, not the
+> writer silently swallowing a *new* one you forgot to declare.
+
+### Rewritten function
+
+```python
+def reporter(reppath: Path, repdata: List[dict]) -> None:
+    if not (reppath and repdata):
+        logger.critical("CHECK-FAIL: Missing report path and/or report data")
+        return
+    reppath = reppath.resolve()
+    write_header = not reppath.exists() or reppath.stat().st_size == 0
+    with open(reppath, "a", encoding="utf-8", newline="") as repobj:
+        writer = DictWriter(repobj, REPORT_FIELDS, extrasaction="ignore")
+        if write_header:
+            writer.writeheader()
+        writer.writerows(repdata)
+```
+
+`writerows` replaces the manual loop — stdlib already does it.
+
+## Check
+
+One `assert`-based self-check, no network, no framework. Call `reporter()` twice against
+a temp file and assert the header appears exactly once.
+
+```python
+def _test_reporter_single_header():
+    import tempfile, os
+    rows = [{"agent": "a", "url": "u", "status code": "200",
+             "response headers": "{}", "cookies": "", "response text": "hi"}]
+    fd, name = tempfile.mkstemp(suffix=".csv")
+    os.close(fd)
+    p = Path(name)
+    try:
+        reporter(p, rows)
+        reporter(p, rows)  # reuse same path
+        text = p.read_text(encoding="utf-8")
+        header = ",".join(REPORT_FIELDS)
+        assert text.count(header) == 1, f"expected 1 header, got {text.count(header)}"
+        assert "request headers" not in text, "phantom column leaked"
+    finally:
+        p.unlink()
+
+# run: python -c "import agent_slammer as m; m._test_reporter_single_header()"
+```

--- a/specs/05-bounded-concurrency.md
+++ b/specs/05-bounded-concurrency.md
@@ -1,0 +1,130 @@
+# 05 — Bounded Concurrency
+
+## Spec
+
+### Problem
+`tasker()` calls `asyncio.create_task(request(...))` once per user-agent in a
+loop, then awaits them. `create_task` schedules the coroutine to run
+*immediately* on the event loop — so by the time the first `await reqtask`
+runs, every request is already in flight. With 50 UAs that's fine. With 500+
+it means 500+ simultaneous sockets and 500+ near-simultaneous GETs at the
+target.
+
+### Why it matters here
+- **The target is usually the user's own service under test.** "Rapid" is the
+  point; "flood" is not. 500 concurrent hits looks like a burst-load event, not
+  a browser/device validation run.
+- **Local socket limits.** Hundreds of simultaneous outbound connections can
+  exhaust ephemeral ports / file descriptors and cause spurious connection
+  errors that look like target failures but aren't.
+- The tool's job is to *walk* a UA list against a target, not to see how hard it
+  can push it.
+
+### Acceptance criteria
+1. No more than **N** requests are in flight (network call active) at any instant.
+2. N is configurable via a `--concurrency` CLI option.
+3. Default is **20**, documented in the option help text.
+4. All requests still complete; results order/content unchanged.
+
+## Plan
+
+Minimal, stdlib `asyncio` only. No new deps.
+
+### Where to gate
+Acquire the semaphore **inside `request()`**, wrapping the actual `aiohttp`
+GET, not in `tasker()` around task creation.
+
+Justification: `create_task` starts the coroutine immediately, so guarding
+task *creation* does nothing — all coroutines are already scheduled. The
+semaphore must sit around the awaited network call so a coroutine blocks there
+until a slot frees. Putting `async with sem:` in `request()` is the smallest
+correct place: the guarded region is exactly the I/O we want to bound, and
+`tasker()` keeps its simple create-all-then-await-all shape.
+
+### Code changes
+
+**1. `slam()` — add the option and thread it through**
+```python
+concurrency: int = typer.Option(
+    20, "--concurrency",
+    help="Max requests in flight at once (default 20)",
+),
+```
+Pass to tasker: `asyncio.run(tasker(url, agents_data, concurrency))`.
+
+**2. `tasker()` — create one semaphore, pass it to each request**
+```python
+async def tasker(target: str, agents: json, concurrency: int) -> List[dict]:
+    if target and agents:
+        sem = asyncio.Semaphore(concurrency)
+        reqtasks = []
+        reqlog = []
+        for agent in track(agents, description="Building task list"):
+            task = asyncio.create_task(request(target=target, agent=agent["ua"], sem=sem))
+            reqtasks.append(task)
+        for reqtask in track(reqtasks, description="Performing queries"):
+            reqlog.append(await reqtask)
+        return reqlog
+```
+
+**3. `request()` — accept `sem`, wrap the GET**
+```python
+async def request(target: str, agent: str, sem: asyncio.Semaphore) -> dict:
+    async with sem:
+        ...  # existing aiohttp GET, unchanged inside the block
+```
+
+That's the whole change: one option, one `Semaphore(...)`, one param threaded
+`slam → tasker → request`, one `async with`.
+
+## Interaction note
+`tasker` and `request` are the **same two functions** touched by the
+session-reuse spec and the redirects/errors (timeout) spec. Coordinate the
+signatures so they land together instead of colliding — the end state for
+`request()` is something like:
+
+```python
+async def request(target, agent, sem, session, timeout) -> dict: ...
+```
+
+with `sem`, the shared `aiohttp.ClientSession`, and the `ClientTimeout` all
+threaded from `slam → tasker → request` in one pass. Whoever lands last should
+merge, not re-add, the parameters. The `async with sem:` here composes cleanly
+inside the shared-session block from the session spec.
+
+## Runnable check
+No network. Prove peak concurrency never exceeds the limit with a fake
+`request` and a shared counter.
+
+```python
+# test_concurrency.py
+import asyncio
+
+async def bounded_gets(concurrency, n):
+    sem = asyncio.Semaphore(concurrency)
+    live = 0
+    peak = 0
+    async def fake_request(i):
+        nonlocal live, peak
+        async with sem:
+            live += 1
+            peak = max(peak, live)
+            await asyncio.sleep(0.01)   # hold the slot so overlap is real
+            live -= 1
+        return i
+    await asyncio.gather(*(fake_request(i) for i in range(n)))
+    return peak
+
+def test_peak_never_exceeds_limit():
+    peak = asyncio.run(bounded_gets(concurrency=3, n=50))
+    assert peak <= 3, f"peak concurrency {peak} exceeded limit 3"
+    assert peak == 3, f"expected saturation at 3, got {peak}"
+
+if __name__ == "__main__":
+    test_peak_never_exceeds_limit()
+    print("ok")
+```
+
+`live`/`peak` mirror the real semaphore-guarded region: increment on enter,
+`sleep` to force overlap, decrement on exit. `peak <= 3` is the bound;
+`peak == 3` confirms the limit isn't accidentally serializing everything.

--- a/specs/06-optional-body.md
+++ b/specs/06-optional-body.md
@@ -1,0 +1,56 @@
+# 06 — Optional response body + response length
+
+## Spec
+
+### Problem
+`request()` stores the full `response text` for every user-agent. A single page
+can be hundreds of KB (a real run against github.com wrote a ~600KB row), so a CSV
+across a large UA list balloons to tens/hundreds of MB — most of it identical HTML.
+For the tool's actual job (does UA X land on flow Y), the load-bearing signals are
+`status code`, `final url`, and `redirect chain`; the full body is rarely needed and
+is expensive to keep.
+
+### Why it matters
+Device-flow validation compares outcomes across UAs. The full HTML is noise for that;
+worse, it makes the CSV slow to open and diff. But the body isn't useless — its *size*
+is a cheap, useful signal (a mobile UA getting a much smaller page is meaningful), and
+occasionally you do want the raw HTML to eyeball one case.
+
+### Acceptance criteria
+- Default run stores **no** `response text` (empty), but always records `response length`.
+- `--body` opt-in flag restores the full `response text` in the CSV.
+- `response length` is present on every successful row regardless of the flag.
+- Columns stay stable whether or not `--body` is set (both `response length` and
+  `response text` columns always exist; text is just blank when the flag is off).
+- Failed rows leave both empty (as today).
+
+## Plan
+
+Minimal, threads one bool through the existing chain. No new deps.
+
+1. **`REPORT_FIELDS`**: insert `"response length"` immediately before `"response text"`.
+2. **`request()`**: add an `include_body: bool` parameter. Body is already read via
+   `await req.text()`; keep reading it (needed for length), then:
+   ```python
+   text = await req.text()
+   reqdata["response length"] = len(text)
+   reqdata["response text"] = text if include_body else ""
+   ```
+   Add `"response length": ""` to the uniform default dict so the key is always present.
+3. **`tasker()`**: add `include_body: bool`, pass it into each `request(...)`.
+4. **`slam()`**: add `body: bool = typer.Option(False, "--body", help="Store full response text (large)")`
+   and thread it: `tasker(url, agent_list, concurrency, timeout, body)`.
+
+### Not doing (YAGNI)
+- No truncation-to-N-bytes middle ground — off or full is enough; add a `--max-body`
+  later only if someone asks.
+- No skipping the body download to save bandwidth. We read it for length anyway; the
+  win here is CSV size, not network. If network becomes the concern, switch to
+  `req.content_length` (header) and stop reading the body — a separate change.
+
+## Runnable check
+The `text if include_body else ""` branch is a trivial one-liner (no test needed per
+the project's own rule). What needs verifying is that the flag actually *threads
+through* `slam → tasker → request`. Extend the existing concurrency test's fake
+`request` to accept `include_body` and assert it receives the value passed to
+`tasker()` — a signature/threading regression then fails loudly, offline.

--- a/test_agent_slammer.py
+++ b/test_agent_slammer.py
@@ -1,0 +1,81 @@
+"""Runnable checks for agent-slammer. No framework, no network deps.
+
+Run: python test_agent_slammer.py
+"""
+import asyncio
+import importlib.util
+import tempfile
+from pathlib import Path
+
+import aiohttp
+
+# agent-slammer.py has a hyphen, so import it by path.
+_spec = importlib.util.spec_from_file_location(
+    "agent_slammer", Path(__file__).parent / "agent-slammer.py"
+)
+m = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(m)
+
+
+def test_error_row_populated():
+    """A failed request still yields a uniform row with error set (spec 01)."""
+    async def _run():
+        sem = asyncio.Semaphore(1)
+        timeout = aiohttp.ClientTimeout(total=1)
+        async with aiohttp.ClientSession(timeout=timeout) as s:
+            return await m.request(s, sem, "http://127.0.0.1:1/", "test-ua", False)
+
+    row = asyncio.run(_run())
+    assert row["error"], "error column must be populated on failure"
+    assert row["status code"] == "", "no status on a failed request"
+    assert row["agent"] == "test-ua", "row must still identify its UA"
+    assert set(m.REPORT_FIELDS) <= set(row), "every CSV column must have a key"
+
+
+def test_reporter_single_header():
+    """Reporter run twice against one file writes exactly one header (spec 04)."""
+    rows = [{"agent": "a", "url": "u", "status code": "200"}]
+    fd, name = tempfile.mkstemp(suffix=".csv")
+    import os
+    os.close(fd)
+    p = Path(name)
+    try:
+        m.reporter(p, rows)
+        m.reporter(p, rows)
+        text = p.read_text(encoding="utf-8")
+        header = ",".join(m.REPORT_FIELDS)
+        assert text.count(header) == 1, f"expected 1 header, got {text.count(header)}"
+        assert "request headers" not in text, "phantom column leaked"
+    finally:
+        p.unlink()
+
+
+def test_concurrency_and_body_threading():
+    """tasker caps in-flight requests (spec 05) and threads include_body (spec 06)."""
+    state = {"cur": 0, "peak": 0, "bodies": set()}
+
+    async def fake_request(session, sem, target, agent, include_body):
+        state["bodies"].add(include_body)
+        async with sem:
+            state["cur"] += 1
+            state["peak"] = max(state["peak"], state["cur"])
+            await asyncio.sleep(0.01)
+            state["cur"] -= 1
+            return {"agent": agent}
+
+    orig = m.request
+    m.request = fake_request
+    try:
+        agents = [{"ua": f"ua{i}"} for i in range(50)]
+        asyncio.run(m.tasker("http://x", agents, concurrency=3, timeout=10, include_body=True))
+        assert state["peak"] == 3, f"peak concurrency was {state['peak']}, expected 3"
+        assert state["bodies"] == {True}, "include_body must thread through to request()"
+    finally:
+        m.request = orig
+
+
+if __name__ == "__main__":
+    test_error_row_populated()
+    test_reporter_single_header()
+    test_concurrency_and_body_threading()
+    print("ok")


### PR DESCRIPTION
Reworks `agent-slammer.py` so it reliably validates browser/device flows across a
large user-agent list, instead of collecting responses in a way that hides the flow
signal and crashes on the first bad UA.

## What changed
- **Redirects & errors (spec 01):** rows now record `final url` and `redirect chain` —
  the actual device-flow signal, previously lost since aiohttp follows redirects
  silently. `request()` wraps the GET in try/except with a `--timeout` (default 10s),
  so one dead/slow UA yields an error row instead of hanging or crashing the run.
- **Session reuse (spec 03):** one `ClientSession` per run instead of one per request.
- **Reporter (spec 04):** header written only when the file is new/empty, phantom
  `request headers` column removed, `newline=""` + `extrasaction="ignore"`, columns
  centralized in a `REPORT_FIELDS` constant.
- **Bounded concurrency (spec 05):** `asyncio.Semaphore` guards the GET, via
  `--concurrency` (default 20).
- **Optional body (spec 06):** `response text` omitted by default (kept
  `response length`); `--body` restores full HTML. Shrinks CSV rows ~100x
  (a github.com row went ~600KB → ~5.7KB).

Each change is spec'd under `specs/` and covered by `test_agent_slammer.py`
(no framework, no network): error-row, single-header, concurrency cap + body
threading. `py test_agent_slammer.py` → `ok`.